### PR TITLE
Bcmath adapter incorrectly handles bases

### DIFF
--- a/src/BigInteger/Adapter/Bcmath.php
+++ b/src/BigInteger/Adapter/Bcmath.php
@@ -314,11 +314,9 @@ class Bcmath implements AdapterInterface
             for ($i = 0, $len  = strlen($operand); $i < $len; $i++) {
                 $decimal = bcmul($decimal, $fromBase);
 
-                if ($fromBase <= 36) {
-                    $remainder = base_convert($operand[$i], $fromBase, 10);
-                } else {
-                    $remainder = strpos($chars, $operand[$i]);
-                }
+                $remainder = ($fromBase <= 36)
+                    ? base_convert($operand[$i], $fromBase, 10)
+                    : strpos($chars, $operand[$i]);
 
                 $decimal = bcadd($decimal, $remainder);
             }
@@ -334,11 +332,12 @@ class Bcmath implements AdapterInterface
             $remainder = bcmod($decimal, $toBase);
             $decimal   = bcdiv($decimal, $toBase);
 
-            if ($toBase <= 36) {
-                $result = base_convert($remainder, 10, $toBase) . $result;
-            } else {
-                $result = $chars[$remainder] . $result;
-            }
+            $intermediate = ($toBase <= 36)
+                ? base_convert($remainder, 10, $toBase)
+                : $chars[$remainder];
+
+            $result = $intermediate . $result;
+
         } while (bccomp($decimal, '0'));
 
         return $sign . $result;

--- a/src/BigInteger/Adapter/Bcmath.php
+++ b/src/BigInteger/Adapter/Bcmath.php
@@ -337,7 +337,6 @@ class Bcmath implements AdapterInterface
                 : $chars[$remainder];
 
             $result = $intermediate . $result;
-
         } while (bccomp($decimal, '0'));
 
         return $sign . $result;

--- a/src/BigInteger/Adapter/Bcmath.php
+++ b/src/BigInteger/Adapter/Bcmath.php
@@ -313,7 +313,14 @@ class Bcmath implements AdapterInterface
             $decimal = '0';
             for ($i = 0, $len  = strlen($operand); $i < $len; $i++) {
                 $decimal = bcmul($decimal, $fromBase);
-                $decimal = bcadd($decimal, strpos($chars, $operand[$i]));
+
+                if ($fromBase <= 36) {
+                    $remainder = base_convert($operand[$i], $fromBase, 10);
+                } else {
+                    $remainder = strpos($chars, $operand[$i]);
+                }
+
+                $decimal = bcadd($decimal, $remainder);
             }
         }
 
@@ -326,7 +333,12 @@ class Bcmath implements AdapterInterface
         do {
             $remainder = bcmod($decimal, $toBase);
             $decimal   = bcdiv($decimal, $toBase);
-            $result    = $chars[$remainder] . $result;
+
+            if ($toBase <= 36) {
+                $result = base_convert($remainder, 10, $toBase) . $result;
+            } else {
+                $result = $chars[$remainder] . $result;
+            }
         } while (bccomp($decimal, '0'));
 
         return $sign . $result;

--- a/test/BigInteger/Adapter/AbstractTestCase.php
+++ b/test/BigInteger/Adapter/AbstractTestCase.php
@@ -318,6 +318,9 @@ abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
             ['499602d2',    16, 10,  '1234567890'],
             ['kf12oi',      36, 10,  '1234567890'],
             ['1ly7vk',      62, 10,  '1234567890'],
+
+            // big integer 16 base
+            ['33B000A84D59A000', 16, 10, '3724477614687625216'],
         ];
     }
 


### PR DESCRIPTION
The Bcmath adapter is attempting to leverage the base62 alphabet for all
of the base conversions against the remainders causing varying bases to
fail.  For instance, uppercase characters that would be leveraged in base
16 fail unless they were lowercase.  The proper way of handling this is to
utilize the built in base_convert function of PHP which can handle up to
base 36 and leverage base62 alphabet for anything greater.
