### PR TITLE
Removed the OpenSSL usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "suggest": {
         "ext-bcmath": "If using the bcmath functionality",
         "ext-gmp": "If using the gmp functionality",
-        "ircmaxell/random-lib": "Fallback random byte generator for Zend\\Math\\Rand if OpenSSL/Mcrypt extensions are unavailable"
+        "ircmaxell/random-lib": "Fallback random byte generator for Zend\\Math\\Rand if Mcrypt extensions is unavailable"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/doc/book/zend.math.introduction.md
+++ b/doc/book/zend.math.introduction.md
@@ -15,8 +15,8 @@ general purpose usage and for cryptographic scopes. To generate good random numb
 uses different approaches. If PHP 7 is running we used the cryptographically secure pseudo-random
 functions [random_bytes](http://php.net/manual/en/function.random-bytes.php) and
 [random_int](http://php.net/manual/en/function.random-int.php), otherwise we use the
-[Mcrypt](http://it.php.net/manual/en/book.mcrypt.php) extension or /dev/urandom source with a mixer
-function provided by . If you don't have a secure random source in your environment the component
+[Mcrypt](http://it.php.net/manual/en/book.mcrypt.php) extension or /dev/urandom source.
+If you don't have a secure random source in your environment the component
 will use the library [ircmaxell/RandomLib](https://github.com/ircmaxell/RandomLib) with a
 medium strength generator.
 

--- a/doc/book/zend.math.introduction.md
+++ b/doc/book/zend.math.introduction.md
@@ -12,20 +12,13 @@ We expect to add more functionalities in the future.
 
 `Zend\Math\Rand` implements a random number generator that is able to generate random numbers for
 general purpose usage and for cryptographic scopes. To generate good random numbers this component
-uses the [OpenSSL](http://php.net/manual/en/book.openssl.php) and the
-[Mcrypt](http://it.php.net/manual/en/book.mcrypt.php) extension of PHP. If you don't have the
-OpenSSL or the Mcrypt extension installed in your environment the component will use the
-[mt\_rand](http://it.php.net/manual/en/function.mt-rand.php) function of PHP as fallback. The
-`mt_rand` is not considered secure for cryptographic purpose, that means if you will try to use it
-to generate secure random number the class will throw an exception.
-
-In particular, the algorithm that generates random bytes in `Zend\Math\Rand` tries to call the
-[openssl\_random\_pseudo\_bytes](http://it.php.net/manual/en/function.openssl-random-pseudo-bytes.php)
-function of the OpenSSL extension if installed. If the OpenSSL extension is not present in the
-system the algorithm tries to use the the
-[mcrypt\_create\_iv](http://it.php.net/manual/en/function.mcrypt-create-iv.php) function of the
-Mcrypt extension (using the `MCRYPT_DEV_URANDOM` parameter). Finally, if the OpenSSL and Mcrypt are
-not installed the generator uses the `mt_rand` function of PHP.
+uses different approaches. If PHP 7 is running we used the cryptographically secure pseudo-random
+functions [random_bytes](http://php.net/manual/en/function.random-bytes.php) and
+[random_int](http://php.net/manual/en/function.random-int.php), otherwise we use the
+[Mcrypt](http://it.php.net/manual/en/book.mcrypt.php) extension or /dev/urandom source with a mixer
+function provided by . If you don't have a secure random source in your environment the component
+will use the library [ircmaxell/RandomLib](https://github.com/ircmaxell/RandomLib) with a
+medium strength generator.
 
 The `Zend\Math\Rand` class offers the following methods to generate random values:
 
@@ -41,8 +34,8 @@ In all these methods the parameter `$strong` specify the usage of a strong rando
 We suggest to set the $strong to true if you need to generate random number for cryptographic and
 security implementation.
 
-If `$strong` is set to true and you try to generate random values in a PHP environment without the
-OpenSSL and the Mcrypt extensions the component will throw an Exception.
+If `$strong` is set to true and you try to generate random values in a PHP environment without a
+secure pseudo-random source the component will throw an Exception.
 
 Below we reported an example on how to generate random data using `Zend\Math\Rand`.
 

--- a/src/BigInteger/BigInteger.php
+++ b/src/BigInteger/BigInteger.php
@@ -78,7 +78,7 @@ abstract class BigInteger
         if (extension_loaded('gmp')) {
             return static::factory('Gmp');
         }
-        
+
         if (extension_loaded('bcmath')) {
             return static::factory('Bcmath');
         }

--- a/src/Rand.php
+++ b/src/Rand.php
@@ -54,7 +54,7 @@ abstract class Rand
         if (true === $strong && false === $checkAlternatives) {
             throw new Exception\RuntimeException(
                 'This PHP environment doesn\'t support secure random number generation. ' .
-                'Please consider installing Mcrypt extension or use PHP 7'
+                'Please consider either installing ext/mcrypt or upgrading to PHP 7'
             );
         }
         $generator = self::getAlternativeGenerator();
@@ -73,8 +73,8 @@ abstract class Rand
         }
         if (!class_exists('RandomLib\\Factory')) {
             throw new Exception\RuntimeException(
-                'The RandomLib fallback pseudorandom number generator (PRNG) '
-                . ' must be installed in the absence of a secure source'
+                'The RandomLib fallback pseudorandom generator is not installed. '.
+                'Please install it to support secure random numbers'
             );
         }
         $factory = new RandomLib\Factory;

--- a/src/Rand.php
+++ b/src/Rand.php
@@ -24,7 +24,8 @@ abstract class Rand
     protected static $generator = null;
 
     /**
-     * Generate random bytes using OpenSSL or Mcrypt and mt_rand() as fallback
+     * Generate random bytes using different approaches
+     * If PHP 7 is running we use the random_bytes() function
      *
      * @param  int $length
      * @param  bool $strong true if you need a strong random generator (cryptography)
@@ -39,11 +40,8 @@ abstract class Rand
             return false;
         }
 
-        if (function_exists('openssl_random_pseudo_bytes')) {
-            $bytes = openssl_random_pseudo_bytes($length, $usable);
-            if (true === $usable) {
-                return $bytes;
-            }
+        if (version_compare(PHP_VERSION, '7.0.0') >= 0) {
+            return random_bytes($length);
         }
         if (function_exists('mcrypt_create_iv')) {
             $bytes = mcrypt_create_iv($length, MCRYPT_DEV_URANDOM);
@@ -56,7 +54,7 @@ abstract class Rand
         if (true === $strong && false === $checkAlternatives) {
             throw new Exception\RuntimeException(
                 'This PHP environment doesn\'t support secure random number generation. ' .
-                'Please consider installing the OpenSSL and/or Mcrypt extensions'
+                'Please consider installing Mcrypt extension or use PHP 7'
             );
         }
         $generator = self::getAlternativeGenerator();
@@ -76,8 +74,7 @@ abstract class Rand
         if (!class_exists('RandomLib\\Factory')) {
             throw new Exception\RuntimeException(
                 'The RandomLib fallback pseudorandom number generator (PRNG) '
-                . ' must be installed in the absence of the OpenSSL and '
-                . 'Mcrypt extensions'
+                . ' must be installed in the absence of a secure source'
             );
         }
         $factory = new RandomLib\Factory;
@@ -116,6 +113,9 @@ abstract class Rand
             throw new Exception\DomainException(
                 'The min parameter must be lower than max parameter'
             );
+        }
+        if (version_compare(PHP_VERSION, '7.0.0') >= 0) {
+            return random_int($min, $max);
         }
         $range = $max - $min;
         if ($range == 0) {

--- a/src/Rand.php
+++ b/src/Rand.php
@@ -40,7 +40,7 @@ abstract class Rand
             return false;
         }
 
-        if (version_compare(PHP_VERSION, '7.0.0') >= 0) {
+        if (function_exists('random_bytes')) { // available in PHP 7
             return random_bytes($length);
         }
         if (function_exists('mcrypt_create_iv')) {
@@ -114,7 +114,7 @@ abstract class Rand
                 'The min parameter must be lower than max parameter'
             );
         }
-        if (version_compare(PHP_VERSION, '7.0.0') >= 0) {
+        if (function_exists('random_int')) { // available in PHP 7
             return random_int($min, $max);
         }
         $range = $max - $min;


### PR DESCRIPTION
This PR removes the usage of the `openssl_random_pseudo_bytes()` function of OpenSSL due to the bug [#70014](https://bugs.php.net/bug.php?id=70014) and the discussion reported [here](https://github.com/paragonie/random_compat/issues/96).
