### PR TITLE
Remove random-lib leftovers in Zend\Math\Rand

### DIFF
--- a/src/Rand.php
+++ b/src/Rand.php
@@ -9,20 +9,11 @@
 
 namespace Zend\Math;
 
-use RandomLib;
-
 /**
  * Pseudorandom number generator (PRNG)
  */
 abstract class Rand
 {
-    /**
-     * Alternative random byte generator using RandomLib
-     *
-     * @var RandomLib\Generator
-     */
-    protected static $generator = null;
-
     /**
      * Generate random bytes using different approaches
      * If PHP 7 is running we use the random_bytes() function


### PR DESCRIPTION
It is no longer possible to set a custom random generator.
This was removed for the 3.0 release of this component.
See: https://github.com/zendframework/zend-math/commit/3bfa3d4db1c224d3bbb6971f6a27ba49ecbfc73c
