### PR TITLE
Fix description of getFloat() interval (it can return 0)

### DIFF
--- a/src/Rand.php
+++ b/src/Rand.php
@@ -103,7 +103,7 @@ abstract class Rand
     }
 
     /**
-     * Generate random float (0..1)
+     * Generate random float [0..1)
      * This function generates floats with platform-dependent precision
      *
      * PHP uses double precision floating-point format (64-bit) which has


### PR DESCRIPTION
getFloat() will return 0 when the mantissa $bytes are all zero, but the documentation for the function states that it returns an interval (0..1) (i.e. exclusive of 0 or 1).

You can test extreme values of the mantissa like so:

```php
<?php

ini_set('precision', 17);

function getFloat($bytes)
{
    $bytes[6] = $bytes[6] | chr(0xF0);
    $bytes   .= chr(63); // exponent bias (1023)
    list(, $float) = unpack('d', $bytes);
    return ($float - 1);
}

echo getFloat(pack('H*', '00000000000000')) . "\n";
echo getFloat(pack('H*', 'FFFFFFFFFFFFFF'));
```

Prints:

```
0
0.99999999999999978
```

So getFloat() actually returns a half-open interval, and is correctly described as [0..1).