### PR TITLE
Added the isSupported() static function

### DIFF
--- a/src/Source/HashTiming.php
+++ b/src/Source/HashTiming.php
@@ -108,4 +108,12 @@ class HashTiming implements RandomLib\Source
         }
         return substr($result, 0, $size);
     }
+
+    /**
+     * {@inheritdoc }
+     */
+    public static function isSupported()
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
This PR fixes #23 for zend-math 2.7.0. This should be released in 2.7.1.